### PR TITLE
Exclude matches without defined players

### DIFF
--- a/snookxporter/clients/snookapp.py
+++ b/snookxporter/clients/snookapp.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -43,7 +44,10 @@ class SnookAppClient:
             for match in schedule
             for court in match['matchCourts']
             for item in court['bookingItems']
-            if item.get('match') and self._is_host_or_guest_in_players(
+            if item.get('match')
+            and item.get('match').get('host')
+            and item.get('match').get('guest')
+            and self._is_host_or_guest_in_players(
                 host=item['match']['host'],
                 guest=item['match']['guest'],
                 players=players


### PR DESCRIPTION
Preventing key errors when there are matches scheduled without defined players.

![image](https://github.com/user-attachments/assets/13096cb6-7a27-4d41-9dba-a21968c5d9ce)